### PR TITLE
[Fix] Missing return statement in "solveThePuzzle" method

### DIFF
--- a/challenge/contracts/algorand-puzzle-2.algo.ts
+++ b/challenge/contracts/algorand-puzzle-2.algo.ts
@@ -5,6 +5,6 @@ import { Contract } from '@algorandfoundation/tealscript';
 // eslint-disable-next-line no-unused-vars
 class AlgorandPuzzle2 extends Contract {
   solveThePuzzle(): string {
-    // return 'You solved the puzzle!';
+    return 'You solved the puzzle!';
   }
 }

--- a/challenge/package.json
+++ b/challenge/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "generate-client": "algokit generate client contracts/artifacts/ --language typescript  --output contracts/clients/{contract_name}Client.ts",
-    "compile-contract": "tealscript contracts/*.algo.ts contracts/artifacts",
+    "compile-contract": "tealscript contracts/algorand-puzzle-2.algo.ts contracts/artifacts",
     "generate-components": "algokit-generate-component contracts/artifacts/AlgorandPuzzle2.arc32.json contracts/artifacts/components",
     "build": "npm run compile-contract && npm run generate-client",
     "test": "npm run build && jest",


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

There was 2 errors:
- The tealscript command wasn't installed.
- The return statement of solveThePuzzle() method was commented out.

Bonus: I don't know if it was part of the challenge, but I have a bug with the "*.algo.ts" syntax in the package.json compile-contract command. The program doesn't find the file, I needed to write the correct filename to compile. It's present in the commit.

**How did you fix the bug?**

For the missing tealscript command, I executed "algokit bootstrap all". It's a local action, so there is nothing to push to correct this issue, it needs to be done on all PC.

For the return statement, I uncommented the line.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-2/assets/162464577/94fef7ea-2e0b-46e8-9682-41c96d776154)