### PR TITLE
fix: return string value to match declared method return value type

### DIFF
--- a/challenge/contracts/algorand-puzzle-2.algo.ts
+++ b/challenge/contracts/algorand-puzzle-2.algo.ts
@@ -5,6 +5,6 @@ import { Contract } from '@algorandfoundation/tealscript';
 // eslint-disable-next-line no-unused-vars
 class AlgorandPuzzle2 extends Contract {
   solveThePuzzle(): string {
-    // return 'You solved the puzzle!';
+    return 'You solved the puzzle!';
   }
 }


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Contract method solveThePuzzle() declared a string return type. The method did not return any value.

**How did you fix the bug?**

Uncommented line 8 as directed, which then returned a string value for the method.

**Console Screenshot:**

<img width="1467" alt="image" src="https://github.com/algorand-coding-challenges/challenge-2/assets/157974735/434eb409-9dfe-44a6-9eae-37773c42970b">