### PR TITLE
bugfix: Uncomment return statement

### DIFF
--- a/challenge/contracts/algorand-puzzle-2.algo.ts
+++ b/challenge/contracts/algorand-puzzle-2.algo.ts
@@ -5,6 +5,6 @@ import { Contract } from '@algorandfoundation/tealscript';
 // eslint-disable-next-line no-unused-vars
 class AlgorandPuzzle2 extends Contract {
   solveThePuzzle(): string {
-    // return 'You solved the puzzle!';
+    return 'You solved the puzzle!';
   }
 }


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->
Return statement of `AlgorandPuzzle2.solveThePuzzle()` was commented out, and therefore, by default, the function returns `undefined`. This is a violation of the typescript definition of the function which says it should return a value of type `string`.

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->
Uncommented the return statement.

I also forgot to pull in dependencies before running `npm run test` the first time, so I received the following error: `sh: 1: tealscript: not found`. This was resolved by running `algokit bootstrap npm`, which under the hood, runs `npm install`, and since tealscript is listed as a dependency in `package.json`, this dependency issue was satisfied.



**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->

![image](https://github.com/algorand-coding-challenges/challenge-2/assets/28127303/82fe9599-b266-429f-9f39-8817edb34e04)

