### PR TITLE
Add bootstrap command in build script

### DIFF
--- a/challenge/contracts/algorand-puzzle-2.algo.ts
+++ b/challenge/contracts/algorand-puzzle-2.algo.ts
@@ -5,6 +5,6 @@ import { Contract } from '@algorandfoundation/tealscript';
 // eslint-disable-next-line no-unused-vars
 class AlgorandPuzzle2 extends Contract {
   solveThePuzzle(): string {
-    // return 'You solved the puzzle!';
+    return 'You solved the puzzle!';
   }
 }

--- a/challenge/package.json
+++ b/challenge/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "bootstrap": "algokit bootstrap all",
     "generate-client": "algokit generate client contracts/artifacts/ --language typescript  --output contracts/clients/{contract_name}Client.ts",
     "compile-contract": "tealscript contracts/*.algo.ts contracts/artifacts",
     "generate-components": "algokit-generate-component contracts/artifacts/AlgorandPuzzle2.arc32.json contracts/artifacts/components",
-    "build": "npm run compile-contract && npm run generate-client",
+    "build": "npm run bootstrap && npm run compile-contract && npm run generate-client",
     "test": "npm run build && jest",
     "lint": "eslint . --ext .ts",
     "fix": "eslint . --ext .ts --fix"


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
`tealscript` was a dependency needed to compile the contracts. But without the project bootstrapped to begin with, this dependency was not set up, resulting in the error `sh: tealscript: command not found`.

**How did you fix the bug?**
`algokit bootstrap all` was added to the `npm run build` script so that whenever the contract is updated, built, and tested, any new dependencies are properly set up. 

**Console Screenshot:**
![Screenshot 2024-03-12 at 10 50 02 PM](https://github.com/algorand-coding-challenges/challenge-2/assets/58460790/d7b586d4-fa4d-48a7-9001-2b3021003ca2)