### PR TITLE
Uncomment return statement in AlgorandPuzzle2

### DIFF
--- a/challenge/contracts/algorand-puzzle-2.algo.ts
+++ b/challenge/contracts/algorand-puzzle-2.algo.ts
@@ -5,6 +5,6 @@ import { Contract } from '@algorandfoundation/tealscript';
 // eslint-disable-next-line no-unused-vars
 class AlgorandPuzzle2 extends Contract {
   solveThePuzzle(): string {
-    // return 'You solved the puzzle!';
+    return 'You solved the puzzle!';
   }
 }


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Checkpoint 3 in the challenge description was missing a step to install the npm dependencies (which includes tealscript).

This results in the following issue:
```
> algorand-puzzle-2@0.0.0 test
> npm run build && jest


> algorand-puzzle-2@0.0.0 build
> npm run compile-contract && npm run generate-client


> algorand-puzzle-2@0.0.0 compile-contract
> tealscript contracts/*.algo.ts contracts/artifacts

sh: line 1: tealscript: command not found
```

**How did you fix the bug?**

Execute `npm install` before running `npm run test`.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-2/assets/1091843/cec63ecd-63bd-4943-a9f9-67013732f32d)

